### PR TITLE
Update SDK provider model

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Main methods:
 - `create_verification(model_id, user_fingerprint, metadata=None)`
 - `verify_token(token)`
 - `register_provider(company_name, email, website)`
+- `update_provider(provider_id, **fields)`
 - `register_model(model_name, version, description, api_endpoint, model_type)`
 
 See [API Reference](docs/api_reference.md) for full details.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -51,6 +51,19 @@ provider = client.register_provider(
 )
 ```
 
+### update_provider
+
+Update provider details. All parameters are optional.
+
+```python
+provider = client.update_provider(
+    "prov_123",
+    pythontrust_center_url="https://acme.ai/trust",
+    github_url="https://github.com/acme",
+    linkedin_url="https://linkedin.com/company/acme",
+)
+```
+
 ### register_model
 
 Register a new model so that verifications can be issued for it.

--- a/src/modelsignature/client.py
+++ b/src/modelsignature/client.py
@@ -97,6 +97,52 @@ class ModelSignatureClient:
             provider_id=str(resp.get("provider_id", "")),
             api_key=str(resp.get("api_key", "")),
             message=resp.get("message", ""),
+            pythontrust_center_url=resp.get("pythontrust_center_url"),
+            github_url=resp.get("github_url"),
+            linkedin_url=resp.get("linkedin_url"),
+            raw_response=resp,
+        )
+
+    def update_provider(
+        self,
+        provider_id: str,
+        company_name: Optional[str] = None,
+        email: Optional[str] = None,
+        website: Optional[str] = None,
+        pythontrust_center_url: Optional[str] = None,
+        github_url: Optional[str] = None,
+        linkedin_url: Optional[str] = None,
+        **kwargs: Any,
+    ) -> ProviderResponse:
+        """Update provider details."""
+
+        data: Dict[str, Any] = {}
+        if company_name is not None:
+            data["company_name"] = company_name
+        if email is not None:
+            data["email"] = email
+        if website is not None:
+            data["website"] = website
+        if pythontrust_center_url is not None:
+            data["pythontrust_center_url"] = pythontrust_center_url
+        if github_url is not None:
+            data["github_url"] = github_url
+        if linkedin_url is not None:
+            data["linkedin_url"] = linkedin_url
+        data.update(kwargs)
+
+        resp = self._request(
+            "PATCH",
+            f"/api/v1/providers/{provider_id}",
+            json=data,
+        )
+        return ProviderResponse(
+            provider_id=str(resp.get("provider_id", provider_id)),
+            api_key=str(resp.get("api_key", "")),
+            message=resp.get("message", ""),
+            pythontrust_center_url=resp.get("pythontrust_center_url"),
+            github_url=resp.get("github_url"),
+            linkedin_url=resp.get("linkedin_url"),
             raw_response=resp,
         )
 

--- a/src/modelsignature/models.py
+++ b/src/modelsignature/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from datetime import datetime, timedelta
 
 
@@ -32,6 +32,9 @@ class ProviderResponse:
     api_key: str
     message: str
     raw_response: Dict[str, Any]
+    pythontrust_center_url: Optional[str] = None
+    github_url: Optional[str] = None
+    linkedin_url: Optional[str] = None
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,3 +30,24 @@ class TestModelSignatureClient:
             ) as mr:  # noqa: E501
                 mr.side_effect = AuthenticationError("Invalid API key")
                 client.create_verification("model", "user")
+
+    @patch("modelsignature.client.ModelSignatureClient._request")
+    def test_update_provider(self, mock_request):
+        mock_request.return_value = {
+            "provider_id": "prov_123",
+            "message": "updated",
+            "pythontrust_center_url": "https://acme.ai/trust",
+            "github_url": "https://github.com/acme",
+            "linkedin_url": "https://linkedin.com/company/acme",
+        }
+        client = ModelSignatureClient(api_key="key")
+        resp = client.update_provider(
+            "prov_123",
+            pythontrust_center_url="https://acme.ai/trust",
+            github_url="https://github.com/acme",
+            linkedin_url="https://linkedin.com/company/acme",
+        )
+        assert resp.provider_id == "prov_123"
+        assert resp.pythontrust_center_url == "https://acme.ai/trust"
+        assert resp.github_url == "https://github.com/acme"
+        assert resp.linkedin_url == "https://linkedin.com/company/acme"


### PR DESCRIPTION
## Summary
- support provider update with optional URLs
- return optional provider URLs from registration
- document update_provider
- test provider update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687839f673c48323bd6c458c5a7a88d2