### PR TITLE
Add HuggingFace sync and model health support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Main methods:
 - `verify_token(token)`
 - `register_provider(company_name, email, website)`
 - `update_provider(provider_id, **fields)`
-- `register_model(model_name, version, description, api_endpoint, model_type)`
+- `register_model(model_name, version, description, api_endpoint, model_type, huggingface_model_id=None, enable_health_monitoring=False)`
+- `sync_huggingface_model(model_id)`
+- `get_model_health(model_id)`
 
 See [API Reference](docs/api_reference.md) for full details.
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -75,7 +75,25 @@ model = client.register_model(
     description="Our custom GPT model",
     api_endpoint="https://api.acme.ai/chat",
     model_type="chat",
+    huggingface_model_id="acme/awesome-model",  # optional
+    enable_health_monitoring=True,
 )
+```
+
+### sync_huggingface_model
+
+Pull the latest metadata for a model from HuggingFace.
+
+```python
+client.sync_huggingface_model(model.model_id)
+```
+
+### get_model_health
+
+Retrieve the current health status for a model.
+
+```python
+health = client.get_model_health(model.model_id)
 ```
 
 ## IdentityQuestionDetector

--- a/src/modelsignature/client.py
+++ b/src/modelsignature/client.py
@@ -153,6 +153,8 @@ class ModelSignatureClient:
         description: str,
         api_endpoint: str,
         model_type: str,
+        huggingface_model_id: Optional[str] = None,
+        enable_health_monitoring: bool = False,
         **kwargs,
     ) -> ModelResponse:
         data = {
@@ -161,6 +163,8 @@ class ModelSignatureClient:
             "description": description,
             "api_endpoint": api_endpoint,
             "model_type": model_type,
+            "huggingface_model_id": huggingface_model_id,
+            "enable_health_monitoring": enable_health_monitoring,
         }
         data.update(kwargs)
         resp = self._request("POST", "/api/v1/models/register", json=data)
@@ -171,6 +175,14 @@ class ModelSignatureClient:
             message=resp.get("message", ""),
             raw_response=resp,
         )
+
+    def sync_huggingface_model(self, model_id: str) -> Dict[str, Any]:
+        """Sync model information from HuggingFace"""
+        return self._request("POST", f"/api/v1/models/{model_id}/sync-huggingface")
+
+    def get_model_health(self, model_id: str) -> Dict[str, Any]:
+        """Get model health status"""
+        return self._request("GET", f"/api/v1/models/{model_id}/health")
 
     def _request(self, method: str, endpoint: str, **kwargs) -> Dict[str, Any]:
         url = urljoin(self.base_url + "/", endpoint.lstrip("/"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -51,3 +51,56 @@ class TestModelSignatureClient:
         assert resp.pythontrust_center_url == "https://acme.ai/trust"
         assert resp.github_url == "https://github.com/acme"
         assert resp.linkedin_url == "https://linkedin.com/company/acme"
+
+    @patch("modelsignature.client.ModelSignatureClient._request")
+    def test_register_model_with_extras(self, mock_request):
+        mock_request.return_value = {
+            "model_id": "mod_123",
+            "name": "AcmeGPT",
+            "version": "1.0.0",
+        }
+        client = ModelSignatureClient(api_key="key")
+        resp = client.register_model(
+            "AcmeGPT",
+            "1.0.0",
+            "desc",
+            "https://api.acme.ai/chat",
+            "chat",
+            huggingface_model_id="acme/awesome-model",
+            enable_health_monitoring=True,
+        )
+        assert resp.model_id == "mod_123"
+        assert resp.name == "AcmeGPT"
+        mock_request.assert_called_with(
+            "POST",
+            "/api/v1/models/register",
+            json={
+                "model_name": "AcmeGPT",
+                "version": "1.0.0",
+                "description": "desc",
+                "api_endpoint": "https://api.acme.ai/chat",
+                "model_type": "chat",
+                "huggingface_model_id": "acme/awesome-model",
+                "enable_health_monitoring": True,
+            },
+        )
+
+    @patch("modelsignature.client.ModelSignatureClient._request")
+    def test_sync_huggingface_model(self, mock_request):
+        mock_request.return_value = {"status": "ok"}
+        client = ModelSignatureClient(api_key="key")
+        resp = client.sync_huggingface_model("mod_123")
+        assert resp["status"] == "ok"
+        mock_request.assert_called_with(
+            "POST", "/api/v1/models/mod_123/sync-huggingface"
+        )
+
+    @patch("modelsignature.client.ModelSignatureClient._request")
+    def test_get_model_health(self, mock_request):
+        mock_request.return_value = {"healthy": True}
+        client = ModelSignatureClient(api_key="key")
+        resp = client.get_model_health("mod_123")
+        assert resp["healthy"] is True
+        mock_request.assert_called_with(
+            "GET", "/api/v1/models/mod_123/health"
+        )


### PR DESCRIPTION
## Summary
- support syncing a model from HuggingFace
- add model health monitoring endpoints
- document new API usage
- test coverage for new features

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785fdc612083239a881bdff591c7e7